### PR TITLE
added init() method to Generator to reset Adjective and Noun list to …

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,6 +8,15 @@ use ClaudioDekker\WordGenerator\Words\Noun;
 class Generator
 {
     /**
+     * @return void
+     */
+    public static function init(): void
+    {
+        Adjective::setWordList([]);
+        Noun::setWordList([]);
+    }
+
+    /**
      * Override the adjectives and nouns that should be used when
      * generating random phrases.
      *

--- a/src/Words/Adjective.php
+++ b/src/Words/Adjective.php
@@ -9,7 +9,7 @@ class Adjective
      *
      * @var string[]
      */
-    protected static $adjectives = [
+    const DEFAULT_ADJECTIVES = [
         'aged', 'ancient', 'autumn', 'billowing', 'bitter', 'blue', 'bold', 'broken',
         'cold', 'cool', 'crimson', 'damp', 'dark', 'dawn', 'delicate', 'divine', 'dry',
         'empty', 'falling', 'floral', 'fragrant', 'frosty', 'green', 'hidden', 'hollow',
@@ -20,11 +20,18 @@ class Adjective
         'weathered', 'wild', 'winter', 'wispy', 'withered', 'young',
     ];
 
+    /** @var array  */
+    protected static $adjectives = [];
+
     /**
      * Get a random adjective.
      */
     public static function random(): string
     {
+        if(empty(self::$adjectives)) {
+            self::setWordList(self::DEFAULT_ADJECTIVES);
+        }
+
         return self::$adjectives[array_rand(self::$adjectives)];
     }
 

--- a/src/Words/Noun.php
+++ b/src/Words/Noun.php
@@ -9,7 +9,7 @@ class Noun
      *
      * @var string[]
      */
-    protected static $nouns = [
+    const DEFAULT_NOUNS = [
         'bird', 'breeze', 'brook', 'bush', 'butterfly', 'cherry', 'cloud', 'darkness',
         'dawn', 'dew', 'dream', 'dust', 'feather', 'field', 'fire', 'firefly', 'flower',
         'fog', 'forest', 'frog', 'frost', 'galaxy', 'glade', 'glitter', 'grass', 'haze',
@@ -20,11 +20,18 @@ class Noun
         'voice', 'water', 'waterfall', 'wave', 'wildflower', 'willow', 'wind', 'wood',
     ];
 
+    /** @var array  */
+    protected static $nouns = [];
+
     /**
      * Get a random noun.
      */
     public static function random(): string
     {
+        if(empty(self::$nouns)) {
+            self::setWordList(self::DEFAULT_NOUNS);
+        }
+
         return self::$nouns[array_rand(self::$nouns)];
     }
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -57,4 +57,13 @@ class GeneratorTest extends TestCase
 
         $this->assertSame('foo bar', Generator::generate());
     }
+
+    /** @test */
+    public function it_can_be_reinitialized(): void
+    {
+        Generator::setWordLists(['foo'], ['bar']);
+        Generator::init();
+
+        $this->assertNotSame('foo bar', Generator::generate());
+    }
 }


### PR DESCRIPTION
…a "default" configuration.

This will mostly be helpful for testing.